### PR TITLE
Keep quiet and don't carry on loaded variables

### DIFF
--- a/rc/zshrc
+++ b/rc/zshrc
@@ -61,5 +61,5 @@ if test -f ~/.gnupg/.gpg-agent-info -a -n "$(pgrep gpg-agent)"; then
   GPG_TTY=$(tty)
   export GPG_TTY
 else
-  eval $(gpg-agent --daemon ~/.gnupg/.gpg-agent-info)
+  eval $(gpg-agent --daemon ~/.gnupg/.gpg-agent-info > /dev/null 2>&1)
 fi


### PR DESCRIPTION
- [x] Quiet the gpg-agent daemon
- [x] Don't export out the `$DATABASE_URL` to the shell